### PR TITLE
fixed deprecated usage of node-uuid in request dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Alexandr Emelin <frvzmb@gmail.com>",
   "contributors": [],
   "dependencies": {
-    "request": "=2.45.0"
+    "request": "=2.87.0"
   },
   "devDependencies": {},
   "scripts": {},


### PR DESCRIPTION
2.45 version of request module currently produce 
```
    console.warn node_modules/node-uuid/uuid.js:48
      [SECURITY] node-uuid: crypto not usable, falling back to insecure Math.random()
```
more details here https://github.com/request/request/pull/2182