### PR TITLE
pass options strictSSL to config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -18,6 +18,7 @@ function Config(options) {
     this.url = url;
     this.token = new Token(options.secret);
     this.timeout = options.timeout;
+    this.strictSSL = options.strictSSL;
 }
 
 module.exports = Config;


### PR DESCRIPTION
somehow it is used here https://github.com/centrifugal/jscent/blob/master/lib/requests.js#L10 but not passed from config